### PR TITLE
fix: nil panic

### DIFF
--- a/pkg/assemble/cdx/util.go
+++ b/pkg/assemble/cdx/util.go
@@ -289,7 +289,7 @@ func buildDependencyList(in []*cydx.BOM, cs *uniqueComponentService) []cydx.Depe
 				continue
 			}
 
-			if len(*dep.Dependencies) == 0 {
+			if len(lo.FromPtr(dep.Dependencies)) == 0 {
 				continue
 			}
 


### PR DESCRIPTION
Fixes nil panic when deps.Dependencies is nil

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of nil pointers in dependency checks to enhance application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->